### PR TITLE
Make GitHub detect *.feline as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text eol=lf
+*.feline linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect your `.feline` files as Forth.  This makes the amount of Forth code jump from 25% to 29%.

Thanks!
