### PR TITLE
Dereference FELINE_EXE properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ else
 	FELINE_EXE = feline
 endif
 
-all: FELINE_EXE
+all: $(FELINE_EXE)
 
-FELINE_EXE:
-	cd src && $(MAKE)
+$(FELINE_EXE):
+	cd src && $(MAKE) ../$(FELINE_EXE)
 
 clean:
 	-rm -f feline feline.exe build


### PR DESCRIPTION
I’m not sure if this was intended or not, but the Makefile in the root directory creates a target called literally `FELINE_EXE` instead of dereferencing the eponymous variable, as in `$(FELINE_EXE)`. This changes that. Also, the recursive invocation of `make` is changed to specifically request this target.